### PR TITLE
Use new TT API endpoint

### DIFF
--- a/lib/transfer_to/client.rb
+++ b/lib/transfer_to/client.rb
@@ -26,7 +26,7 @@ module TransferToApi
     # Default: get
     # Determines the type of request issued (get|post).
     def run_action(name, params = {}, method = :post)
-      aurl     = "https://fm.transfer-to.com:5443"
+      aurl     = "https://airtime.transferto.com:5443"
 
       if @username.nil?
         if TransferToApi.config.username.nil?

--- a/lib/transfer_to/client.rb
+++ b/lib/transfer_to/client.rb
@@ -26,7 +26,7 @@ module TransferToApi
     # Default: get
     # Determines the type of request issued (get|post).
     def run_action(name, params = {}, method = :post)
-      aurl     = "https://airtime.transferto.com:5443"
+      aurl     = "https://airtime.transferto.com"
 
       if @username.nil?
         if TransferToApi.config.username.nil?

--- a/lib/transfer_to/version.rb
+++ b/lib/transfer_to/version.rb
@@ -1,3 +1,3 @@
 module TransferToApi
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
Dear Robin and RechargeOps Team,

We have upgraded our highly available infrastructure and setup a new Airtime API endpoint that provides better performance and security with the support of TLS 1.2.

Please update your applications before 31st Oct 2017 to call this new endpoint (new Domain name & IP) https://airtime.transferto.com/cgi-bin/shop/topup (instead of https://fm.transfer-to.com/cgi-bin/shop/topup).

The current endpoint will remain available over the next few weeks to give you time to test and perform the migration safely, you can already access it using your existing credentials. No other changes are expected in your configuration.

Please do not hesitate to contact us at migration@transfer-to.com if you have any questions or need assistance during your testing and migration.

Kind Regards,