### PR TITLE
CT-628 - Update transferto timeout

### DIFF
--- a/lib/transfer_to/request.rb
+++ b/lib/transfer_to/request.rb
@@ -2,8 +2,8 @@ module TransferToApi
   # This is the request class to issue requests against the TransferTo API.
   class Request
 
-    OPEN_TIMEOUT = 5
     READ_TIMEOUT = 30
+    OPEN_TIMEOUT = 5
 
     attr_reader :user, :name, :params
 
@@ -13,11 +13,7 @@ module TransferToApi
       @pass   = password
       @conn = Faraday.new(url: aurl) do |faraday|
         faraday.request  :url_encoded
-        faraday.adapter  :net_http do |http| # yields Net::HTTP
-          http.open_timeout = OPEN_TIMEOUT
-          http.read_timeout = READ_TIMEOUT
-        end
-
+        faraday.adapter  :net_http
       end
     end
 
@@ -94,8 +90,8 @@ module TransferToApi
     def run(method = :get)
       add_param :method, method
       @conn.send(method, "/cgi-bin/shop/topup", @params) do |req|
-        req.options.timeout = 300
-        req.options.open_timeout = 60
+        req.options.timeout = READ_TIMEOUT
+        req.options.open_timeout = OPEN_TIMEOUT
       end
     end
 

--- a/lib/transfer_to/version.rb
+++ b/lib/transfer_to/version.rb
@@ -1,3 +1,3 @@
 module TransferToApi
-  VERSION = "2.1.6"
+  VERSION = "2.1.7"
 end


### PR DESCRIPTION
After the last changes, the timeouts were defined both on the connection level and on the request level.
This commit cancel the previous update and keep the definition on the request level. The timeouts value have been updated to 5s for the open_timeout and 30s for the read_timeout.

https://creativegroupdev.atlassian.net/browse/CT-628