### PR TITLE
Fix for is_pin_based? method

### DIFF
--- a/lib/transfer_to/operator.rb
+++ b/lib/transfer_to/operator.rb
@@ -8,10 +8,5 @@ module TransferToApi
       @id = id
     end
 
-    def is_pin_based?
-      name_parts = name.split(' ')
-      return true if name_parts.include?('PIN')
-      false
-    end
   end
 end

--- a/lib/transfer_to/pricelist_product.rb
+++ b/lib/transfer_to/pricelist_product.rb
@@ -16,8 +16,9 @@ module TransferToApi
       @fx_rate = response.data[:fx_rate]
     end
 
+    # product_type seems to be either 'Airtime PIN Based' or 'Airtime PIN Less'
     def is_pin_based?
-      operator.is_pin_based?
+      @product_type.include?('PIN Based')
     end
   end
 end

--- a/lib/transfer_to/version.rb
+++ b/lib/transfer_to/version.rb
@@ -1,3 +1,3 @@
 module TransferToApi
-  VERSION = "2.1.7"
+  VERSION = "2.1.8"
 end


### PR DESCRIPTION
We were using the operator name to determine the product type. Seems they have introduced a method for this in the API for this instead.
This PR makes use of that to fix some issues where PIN products were set as RTR instead in DCGW because of the old way of determining this.